### PR TITLE
Add service to refresh recent images cache

### DIFF
--- a/scripts/update_recent_images_service.py
+++ b/scripts/update_recent_images_service.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Background service to update recent images cache periodically."""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "update_recent_images.py"
+CACHE_FILE = REPO_ROOT / "logs" / "image_cache.json"
+INTERVAL = 3600  # seconds
+
+
+def run_update() -> None:
+    """Execute the update_recent_images script."""
+    subprocess.run([sys.executable, str(SCRIPT)], check=True)
+
+
+def main() -> None:
+    if not CACHE_FILE.exists():
+        run_update()
+
+    while True:
+        run_update()
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,3 +16,12 @@ stderr_logfile=/logs/watcher-error.log
 stdout_logfile=/logs/watcher.log
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
+
+[program:update_recent_images_service]
+command=/opt/venv/bin/python3 /var/www/html/scripts/update_recent_images_service.py
+autostart=true
+autorestart=true
+stderr_logfile=/logs/update_recent_images_service-error.log
+stdout_logfile=/logs/update_recent_images_service.log
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary
- Introduce `update_recent_images_service.py` to refresh `logs/image_cache.json` hourly, ensuring cache exists on startup.
- Register the new service in `supervisord.conf` so it launches with the container.

## Testing
- `python -m py_compile scripts/update_recent_images_service.py`
- `timeout 1 python scripts/update_recent_images_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68968c4b2eb48320990d5c88b3896112