### PR TITLE
Grant permissions to app files in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy app source
 COPY . /var/www/html/
+RUN chmod -R 777 /var/www/html
 WORKDIR /var/www/html/
 
 # Copy nginx and supervisor config


### PR DESCRIPTION
## Summary
- add a chmod step after copying the application into the image so runtime processes can modify files

## Testing
- ⚠️ `docker build .` *(fails in container: `docker` not available)*

------
https://chatgpt.com/codex/tasks/task_e_68ce76be135c8320b27ebb595c210878