### PR TITLE
Ensure writable shared directories for Artillery runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,18 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy app source
 COPY . /var/www/html/
+RUN set -eux; \
+    mkdir -p /downloads /logs /screenshots /tasks /config; \
+    for dir in downloads logs screenshots tasks config; do \
+        src="/var/www/html/$dir"; \
+        dest="/$dir"; \
+        if [ -d "$src" ] && [ -n "$(ls -A "$src" 2>/dev/null)" ]; then \
+            cp -a "$src/." "$dest/"; \
+        fi; \
+        rm -rf "$src"; \
+        ln -s "$dest" "$src"; \
+    done; \
+    chmod -R 777 /var/www/html /downloads /logs /screenshots /tasks /config
 WORKDIR /var/www/html/
 
 # Copy nginx and supervisor config


### PR DESCRIPTION
## Summary
- create the expected shared data directories at the container root, migrate any seeded files into them, and expose them back to the app via symlinks
- keep the application tree and shared directories world-writable so PHP and Python processes can modify downloads, logs, screenshots, tasks, and config files

## Testing
- ⚠️ `docker build .` *(fails in container: `docker` command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68ce76be135c8320b27ebb595c210878