### PR TITLE
Ensure web root permissions after copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy app source
 COPY . /var/www/html/
+RUN chmod -R 777 /var/www/html
 WORKDIR /var/www/html/
 
 # Copy nginx and supervisor config


### PR DESCRIPTION
## Summary
- add a chmod step immediately after copying the application into /var/www/html so the web root remains writable for runtime processes

## Testing
- ⚠️ `docker build .` *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce76be135c8320b27ebb595c210878