### PR TITLE
Ensure runtime directories have writable permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,21 @@ RUN python3 -m venv /opt/venv && \
 ENV PATH="/opt/venv/bin:$PATH" 
 
 # Copy app source
-COPY . /var/www/html/ 
-RUN chmod -R 777 /var/www/html 
-WORKDIR /var/www/html/ 
+COPY . /var/www/html/
+RUN chmod -R 777 /var/www/html
+WORKDIR /var/www/html/
 
-# Copy nginx and supervisor config 
+# Copy nginx and supervisor config
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf
+
+# Copy entrypoint script responsible for directory permissions
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Expose HTTP
 EXPOSE 80
 
-# Start services
+# Start services through the entrypoint to ensure permissions are set
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ docker run -d \
   -v /path/to/config:/config \
   --name artillery \
   your-artillery-image
+```
+
+The container entrypoint ensures `/config`, `/logs`, and `/downloads` exist (creating them when necessary) and assigns permissive
+permissions before launching Supervisord, so bind-mounted volumes are ready for PHP-FPM as soon as the services start.

--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@ $imageLimit = 200; // Max images to retrieve
 // Ensure directories exist
 foreach ([$logDir, $downloadsDir] as $dir) {
     if (!is_dir($dir)) {
-        mkdir($dir, 0755, true);
+        mkdir($dir, 0777, true);
     }
 }
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_DIR="/config"
+LOGS_DIR="/logs"
+DOWNLOADS_DIR="/downloads"
+DIRECTORIES=($CONFIG_DIR $LOGS_DIR $DOWNLOADS_DIR)
+
+for dir in "${DIRECTORIES[@]}"; do
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir"
+    fi
+
+    # Attempt to ensure www-data owns the directory for PHP-FPM access
+    if id -u www-data >/dev/null 2>&1; then
+        chown -R www-data:www-data "$dir" 2>/dev/null || true
+    fi
+
+    chmod 0777 "$dir" || true
+
+done
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a startup entrypoint script that creates /config, /logs, and /downloads with permissive ownership before services launch
- update the Dockerfile to install the entrypoint, run it ahead of supervisord, and document the behavior in the README
- adjust the PHP UI directory creation to default to 0777 so new folders match container expectations

## Testing
- php -l index.php
- ./scripts/entrypoint.sh echo "entrypoint test"
- docker build -t artillery-test . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8260387c83209c143b0f2a156cc7