### PR TITLE
Ensure gallery-dl updates on container startup

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,4 +20,11 @@ for dir in "${DIRECTORIES[@]}"; do
 
 done
 
+if [ -x /opt/venv/bin/pip ]; then
+    echo "Updating gallery-dl to the latest version..."
+    if ! /opt/venv/bin/pip install --no-cache-dir --upgrade gallery-dl; then
+        echo "Warning: Failed to update gallery-dl; continuing with existing version." >&2
+    fi
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary
- update the entrypoint script to refresh gallery-dl with pip when the container starts
- continue container startup even if the upgrade fails, logging a warning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecacbb44988320b37a850187a6c824