### PR TITLE
Run gallery-dl update asynchronously during startup

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -30,6 +30,7 @@ if [ -x /opt/venv/bin/pip ]; then
             echo "$(date --iso-8601=seconds) gallery-dl update completed successfully." >>"${UPDATE_LOG}"
         else
             echo "$(date --iso-8601=seconds) Warning: gallery-dl update failed; continuing with existing version." >>"${UPDATE_LOG}"
+            echo "Warning: gallery-dl update failed; continuing with existing version. See ${UPDATE_LOG} for details." >&2
         fi
     ) &
 fi


### PR DESCRIPTION
## Summary
- run the gallery-dl upgrade in the background during container startup so services can come up immediately
- log upgrade progress and failures to /logs/gallery-dl-update.log and notify via stderr where to find the log

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecacbb44988320b37a850187a6c824