### PR TITLE
Make gallery-dl auto-update optional in CI

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,4 +20,48 @@ for dir in "${DIRECTORIES[@]}"; do
 
 done
 
+SKIP_GALLERY_DL_UPDATE=0
+SKIP_REASON=""
+if [ "${CI:-}" = "true" ]; then
+    SKIP_GALLERY_DL_UPDATE=1
+    SKIP_REASON="CI environment"
+fi
+if [ -n "${DISABLE_GALLERY_DL_AUTOUPDATE:-}" ]; then
+    SKIP_GALLERY_DL_UPDATE=1
+    if [ -z "$SKIP_REASON" ]; then
+        SKIP_REASON="DISABLE_GALLERY_DL_AUTOUPDATE is set"
+    else
+        SKIP_REASON="${SKIP_REASON}; DISABLE_GALLERY_DL_AUTOUPDATE is set"
+    fi
+fi
+
+if [ -x /opt/venv/bin/pip ] && [ "$SKIP_GALLERY_DL_UPDATE" -eq 0 ]; then
+    UPDATE_LOG="${LOGS_DIR}/gallery-dl-update.log"
+    echo "Starting background update of gallery-dl; logs at ${UPDATE_LOG}" >&2
+    (
+        set +e
+        sleep 2
+        echo "$(date --iso-8601=seconds) Updating gallery-dl to the latest version..." >>"${UPDATE_LOG}"
+        INSTALL_CMD=(/opt/venv/bin/pip install --no-cache-dir --upgrade gallery-dl)
+        if command -v nice >/dev/null 2>&1; then
+            INSTALL_CMD=(nice -n 10 "${INSTALL_CMD[@]}")
+        fi
+        if command -v ionice >/dev/null 2>&1; then
+            INSTALL_CMD=(ionice -c3 "${INSTALL_CMD[@]}")
+        fi
+        if "${INSTALL_CMD[@]}" >>"${UPDATE_LOG}" 2>&1; then
+            echo "$(date --iso-8601=seconds) gallery-dl update completed successfully." >>"${UPDATE_LOG}"
+        else
+            echo "$(date --iso-8601=seconds) Warning: gallery-dl update failed; continuing with existing version." >>"${UPDATE_LOG}"
+            echo "Warning: gallery-dl update failed; continuing with existing version. See ${UPDATE_LOG} for details." >&2
+        fi
+    ) &
+elif [ "$SKIP_GALLERY_DL_UPDATE" -eq 1 ]; then
+    if [ -n "$SKIP_REASON" ]; then
+        echo "Skipping gallery-dl auto-update (${SKIP_REASON})." >&2
+    else
+        echo "Skipping gallery-dl auto-update (disabled via environment)." >&2
+    fi
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary
- skip the background gallery-dl upgrade when running in CI or when DISABLE_GALLERY_DL_AUTOUPDATE is set
- run the updater with a short delay and reduced priority so startup services initialize promptly
- log the skip reason to stderr for visibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecacbb44988320b37a850187a6c824