### PR TITLE
Rebuild Artillery UI with Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Artillery
 
-**Artillery** is a sleek web UI for managing `gallery-dl` download tasks. It lets you create, edit, schedule, and manually run gallery-dl jobs from a modern, dark-themed interface—complete with logging, archiving, and task control.
+Artillery is a Flask-powered web UI for managing `gallery-dl` download tasks. It lets you create, edit, schedule, and manually run gallery-dl jobs from a modern, dark-themed interface—complete with logging, archiving, and task control.
 
 ![Artillery Banner](screenshots/banner.png)
 
 ## 🚀 Features
 
 - 🔧 Task creation with full gallery-dl command customization
-- 🕓 Interval-based scheduling (every X minutes)
+- 🕓 Interval-based scheduling handled by a Python watcher
 - 📜 Task logging with live command output
 - 📁 Automatic archive handling
 - 🧠 Pause/resume functionality
-- ✅ Docker-ready
+- ✅ Docker-ready with Gunicorn + Supervisor
 
 ## 🖥️ Interface
 
@@ -31,7 +31,7 @@ Configure gallery URLs and fine-tune flags like rate limits, retries, sleep inte
 
 ```bash
 docker run -d \
-  -p 8080:80 \
+  -p 8080:8000 \
   -e PUID=1000 \
   -e PGID=1000 \
   -v /path/to/tasks:/tasks \
@@ -42,5 +42,16 @@ docker run -d \
   your-artillery-image
 ```
 
-The container entrypoint ensures `/config`, `/logs`, and `/downloads` exist (creating them when necessary) and assigns permissive
-permissions before launching Supervisord, so bind-mounted volumes are ready for PHP-FPM as soon as the services start.
+The entrypoint ensures `/config`, `/logs`, `/tasks`, and `/downloads` exist (creating them when necessary) before launching Supervisor. Gunicorn serves the Flask UI on port `8000`, while the background watcher handles scheduled tasks and the recent-images refresher keeps homepage thumbnails fresh.
+
+## 🛠️ Local development
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+export FLASK_APP=app:create_app
+flask run --host=0.0.0.0 --port=8000
+```
+
+Scheduler/watcher helpers use the same directories as the container build (`/tasks`, `/downloads`, `/logs`, `/config`). You can override them with environment variables if you prefer local paths.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+from flask import Flask
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config.update(
+        SECRET_KEY=os.environ.get("SECRET_KEY", "artillery-dev-secret"),
+        TASK_DIR=Path(os.environ.get("TASK_DIR", "/tasks")),
+        DOWNLOAD_DIR=Path(os.environ.get("DOWNLOAD_DIR", "/downloads")),
+        LOG_DIR=Path(os.environ.get("LOG_DIR", "/logs")),
+        CONFIG_FILE=Path(os.environ.get("CONFIG_FILE", "/config/config.json")),
+        PYTHON_BIN=os.environ.get("PYTHON_BIN", sys.executable),
+        RUNNER_TASK=Path(os.environ.get("RUNNER_TASK", "/app/runner_task.py")),
+        RUNNER_SINGLE=Path(os.environ.get("RUNNER_SINGLE", "/app/runner_single.py")),
+    )
+
+    for directory in (app.config["TASK_DIR"], app.config["DOWNLOAD_DIR"], app.config["LOG_DIR"], app.config["CONFIG_FILE"].parent):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    from .routes import bp
+
+    app.register_blueprint(bp)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,240 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+from flask import Blueprint, Response, current_app, flash, jsonify, redirect, render_template, request, send_from_directory, url_for
+
+from .task_service import TaskService
+
+bp = Blueprint("artillery", __name__)
+
+
+def service() -> TaskService:
+    cfg = current_app.config
+    return TaskService(
+        task_dir=cfg["TASK_DIR"],
+        download_dir=cfg["DOWNLOAD_DIR"],
+        log_dir=cfg["LOG_DIR"],
+        config_file=cfg["CONFIG_FILE"],
+        runner_task=cfg["RUNNER_TASK"],
+        runner_single=cfg["RUNNER_SINGLE"],
+        python_bin=cfg["PYTHON_BIN"],
+    )
+
+
+@bp.route("/", methods=["GET", "POST"])
+def home() -> str:
+    svc = service()
+    output = None
+    if request.method == "POST":
+        url = request.form.get("gallery_url", "").strip()
+        if not url:
+            flash("Please enter a URL.", "error")
+        else:
+            try:
+                result = svc.run_single(url)
+                output = (result.stdout or "") + ("\n" + result.stderr if result.stderr else "")
+                if result.returncode == 0:
+                    flash("Download started successfully. Check recent images below.", "success")
+                    cache_file = current_app.config["LOG_DIR"] / "image_cache.json"
+                    svc.get_recent_images(cache_file)
+                else:
+                    flash("Download reported an error.", "error")
+            except Exception as exc:  # noqa: BLE001
+                flash(str(exc), "error")
+
+    cache_file = current_app.config["LOG_DIR"] / "image_cache.json"
+    images = svc.get_recent_images(cache_file)
+    return render_template("home.html", images=images, output=output)
+
+
+@bp.route("/tasks", methods=["GET"])
+def list_tasks() -> str:
+    svc = service()
+    tasks = svc.list_tasks()
+    return render_template("tasks.html", tasks=tasks)
+
+
+@bp.route("/tasks/status")
+def task_status() -> Response:
+    svc = service()
+    tasks = svc.list_tasks()
+    payload = [
+        {
+            "name": t["name"],
+            "status": t["status"],
+            "last_run": t["last_run"],
+            "interval": t["interval"],
+            "next_run": t["next_run"],
+            "is_paused": t["status"] == "Paused",
+        }
+        for t in tasks
+    ]
+    return jsonify(payload)
+
+
+def _extract_form_flags(form: Dict) -> Dict:
+    boolean_fields = [
+        "write_unsupported",
+        "no_skip",
+        "write_metadata",
+        "write_info_json",
+        "write_tags",
+        "use_cookies",
+        "use_download_archive",
+    ]
+    text_fields = [
+        "retries",
+        "limit_rate",
+        "sleep",
+        "sleep_request",
+        "sleep_429",
+        "sleep_extractor",
+        "rename",
+        "rename_to",
+    ]
+    data: Dict[str, object] = {}
+    for field in boolean_fields:
+        data[field] = form.get(field) is not None
+    for field in text_fields:
+        data[field] = form.get(field, "").strip()
+    data["input_mode"] = form.get("input_mode", "i")
+    return data
+
+
+@bp.route("/tasks/new", methods=["GET", "POST"])
+def new_task() -> str:
+    svc = service()
+    if request.method == "POST":
+        name = request.form.get("task_name", "")
+        urls = request.form.get("url_list", "")
+        interval = int(request.form.get("interval", 0))
+        flags = _extract_form_flags(request.form)
+
+        if not name or not urls or interval < 1:
+            flash("Task name, URLs, and a valid interval are required.", "error")
+        else:
+            try:
+                svc.create_task(name, urls, interval, flags)
+                flash(f"Task '{name}' created.", "success")
+                return redirect(url_for("artillery.list_tasks"))
+            except FileExistsError:
+                flash("Task already exists.", "error")
+            except Exception as exc:  # noqa: BLE001
+                flash(str(exc), "error")
+
+    return render_template("task_form.html", mode="new", task=None, task_name="")
+
+
+@bp.route("/tasks/<task_name>/edit", methods=["GET", "POST"])
+def edit_task(task_name: str) -> str:
+    svc = service()
+    task = svc.load_task(task_name)
+    if not task:
+        flash("Task not found.", "error")
+        return redirect(url_for("artillery.list_tasks"))
+
+    if request.method == "POST":
+        urls = request.form.get("url_list", "")
+        interval = int(request.form.get("interval", 0))
+        flags = _extract_form_flags(request.form)
+
+        if not urls or interval < 1:
+            flash("URL list and valid interval are required.", "error")
+        else:
+            try:
+                svc.update_task(task_name, urls, interval, flags)
+                flash(f"Task '{task_name}' updated.", "success")
+                return redirect(url_for("artillery.list_tasks"))
+            except Exception as exc:  # noqa: BLE001
+                flash(str(exc), "error")
+
+        task = svc.load_task(task_name)
+
+    return render_template("task_form.html", mode="edit", task=task, task_name=task_name)
+
+
+@bp.route("/tasks/<task_name>/run", methods=["POST"])
+def run_task(task_name: str) -> Response:
+    svc = service()
+    try:
+        svc.run_task(task_name)
+        flash(f"Task '{task_name}' started.", "success")
+    except Exception as exc:  # noqa: BLE001
+        flash(str(exc), "error")
+    return redirect(url_for("artillery.list_tasks"))
+
+
+@bp.route("/tasks/<task_name>/pause", methods=["POST"])
+def pause_task(task_name: str) -> Response:
+    svc = service()
+    try:
+        paused = svc.toggle_pause(task_name)
+        flash(("Task paused" if paused else "Task resumed") + f": {task_name}", "success")
+    except Exception as exc:  # noqa: BLE001
+        flash(str(exc), "error")
+    return redirect(url_for("artillery.list_tasks"))
+
+
+@bp.route("/tasks/<task_name>/delete", methods=["POST"])
+def delete_task(task_name: str) -> Response:
+    svc = service()
+    try:
+        svc.delete_task(task_name)
+        flash(f"Task '{task_name}' deleted.", "success")
+    except Exception as exc:  # noqa: BLE001
+        flash(str(exc), "error")
+    return redirect(url_for("artillery.list_tasks"))
+
+
+@bp.route("/tasks/<task_name>/archive", methods=["POST"])
+def delete_archive(task_name: str) -> Response:
+    svc = service()
+    if svc.delete_archive(task_name):
+        flash(f"Archive for '{task_name}' deleted.", "success")
+    else:
+        flash("Archive not found.", "error")
+    return redirect(url_for("artillery.list_tasks"))
+
+
+@bp.route("/tasks/<task_name>/log")
+def view_log(task_name: str) -> str:
+    svc = service()
+    log_contents = svc.read_log(task_name)
+    return render_template("log_view.html", task_name=task_name, log_contents=log_contents)
+
+
+@bp.route("/config", methods=["GET", "POST"])
+def config_editor() -> str:
+    cfg_file: Path = current_app.config["CONFIG_FILE"]
+    current_content = cfg_file.read_text(encoding="utf-8") if cfg_file.exists() else ""
+
+    if request.method == "POST":
+        new_content = request.form.get("config_content", "")
+        try:
+            json.loads(new_content)
+        except json.JSONDecodeError:
+            flash("Invalid JSON. Config not saved.", "error")
+            return render_template("config.html", content=current_content)
+
+        if cfg_file.exists():
+            backup = cfg_file.with_suffix(cfg_file.suffix + ".bak")
+            backup.write_text(current_content, encoding="utf-8")
+
+        cfg_file.parent.mkdir(parents=True, exist_ok=True)
+        cfg_file.write_text(new_content, encoding="utf-8")
+        flash("Config saved successfully.", "success")
+        current_content = new_content
+
+    return render_template("config.html", content=current_content)
+
+
+@bp.route("/downloads/<path:filename>")
+def downloads(filename: str) -> Response:
+    return send_from_directory(current_app.config["DOWNLOAD_DIR"], filename)
+
+
+@bp.route("/favicon.ico")
+def favicon() -> Response:
+    repo_root = Path(current_app.root_path).parent
+    return send_from_directory(repo_root, "favicon.ico")

--- a/app/task_service.py
+++ b/app/task_service.py
@@ -1,0 +1,263 @@
+import json
+import re
+import shlex
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".tiff", ".svg"}
+
+BOOLEAN_FLAGS = {
+    "--write-unsupported": "write_unsupported",
+    "--no-skip": "no_skip",
+    "--write-metadata": "write_metadata",
+    "--write-info-json": "write_info_json",
+    "--write-tags": "write_tags",
+}
+
+TEXT_FLAGS = {
+    "--retries": "retries",
+    "--limit-rate": "limit_rate",
+    "--sleep": "sleep",
+    "--sleep-request": "sleep_request",
+    "--sleep-429": "sleep_429",
+    "--sleep-extractor": "sleep_extractor",
+    "--rename": "rename",
+    "--rename-to": "rename_to",
+}
+
+
+class TaskService:
+    def __init__(
+        self,
+        task_dir: Path,
+        download_dir: Path,
+        log_dir: Path,
+        config_file: Path,
+        runner_task: Path,
+        runner_single: Path,
+        python_bin: str,
+    ) -> None:
+        self.task_dir = task_dir
+        self.download_dir = download_dir
+        self.log_dir = log_dir
+        self.config_file = config_file
+        self.runner_task = runner_task
+        self.runner_single = runner_single
+        self.python_bin = python_bin
+
+    def list_tasks(self) -> List[Dict]:
+        tasks: List[Dict] = []
+        if not self.task_dir.exists():
+            return tasks
+
+        for entry in sorted(self.task_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            task = self._build_task(entry)
+            tasks.append(task)
+        return tasks
+
+    def _build_task(self, path: Path) -> Dict:
+        name = path.name
+        interval_file = path / "interval.txt"
+        last_run_file = path / "last_run.txt"
+        lockfile = path / "lockfile"
+        pause_file = path / "paused.txt"
+        log_file = path / "log.txt"
+
+        interval = self._read(interval_file)
+        last_run = self._read(last_run_file)
+
+        interval_minutes = int(interval) if interval and interval.isdigit() else 0
+        last_run_dt = datetime.strptime(last_run, "%Y-%m-%d %H:%M:%S") if last_run else None
+        next_run = None
+        if interval_minutes and last_run_dt and not pause_file.exists():
+            next_run = last_run_dt + timedelta(minutes=interval_minutes)
+
+        return {
+            "name": name,
+            "display_name": name.replace("_", " "),
+            "interval": interval_minutes,
+            "last_run": last_run if last_run else "-",
+            "next_run": next_run.strftime("%Y-%m-%d %H:%M:%S") if next_run else "-",
+            "status": "Running" if lockfile.exists() else "Paused" if pause_file.exists() else "Idle",
+            "has_log": log_file.exists(),
+            "command": self._read(path / "command.txt") or "",
+        }
+
+    def load_task(self, name: str) -> Optional[Dict]:
+        path = self.task_dir / name
+        if not path.is_dir():
+            return None
+        data = self._build_task(path)
+        data.update(
+            {
+                "url_list": self._read(path / "url_list.txt") or "",
+                "input_mode": "i",
+                "flags": {value: False for value in BOOLEAN_FLAGS.values()},
+                "values": {value: "" for value in TEXT_FLAGS.values()},
+                "use_cookies": False,
+                "use_download_archive": False,
+            }
+        )
+
+        command = self._read(path / "command.txt") or ""
+        parsed = self.parse_command(command)
+        data.update(parsed)
+        return data
+
+    def parse_command(self, command: str) -> Dict:
+        tokens = shlex.split(command)
+        flags = {value: False for value in BOOLEAN_FLAGS.values()}
+        values = {value: "" for value in TEXT_FLAGS.values()}
+        input_mode = "i"
+        use_cookies = False
+        use_download_archive = False
+
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+            if token in ("-i", "-I"):
+                input_mode = token[1]
+            if token in BOOLEAN_FLAGS:
+                flags[BOOLEAN_FLAGS[token]] = True
+            if token in TEXT_FLAGS and i + 1 < len(tokens):
+                values[TEXT_FLAGS[token]] = tokens[i + 1]
+                i += 1
+            if token == "-C" and i + 1 < len(tokens) and tokens[i + 1] == "cookies.txt":
+                use_cookies = True
+                i += 1
+            if token == "--download-archive":
+                use_download_archive = True
+                i += 1
+            i += 1
+
+        return {
+            "input_mode": input_mode,
+            "flags": flags,
+            "values": values,
+            "use_cookies": use_cookies,
+            "use_download_archive": use_download_archive,
+        }
+
+    def create_task(self, name: str, url_list: str, interval: int, form_data: Dict) -> None:
+        safe_name = re.sub(r"[^\w\-]", "_", name.strip())
+        if not safe_name:
+            raise ValueError("Task name is required")
+        task_path = self.task_dir / safe_name
+        task_path.mkdir(parents=True, exist_ok=False)
+
+        (task_path / "url_list.txt").write_text(url_list.strip(), encoding="utf-8")
+        (task_path / "interval.txt").write_text(str(interval), encoding="utf-8")
+
+        command = self._build_command(safe_name, task_path, form_data)
+        (task_path / "command.txt").write_text(command, encoding="utf-8")
+
+    def update_task(self, name: str, url_list: str, interval: int, form_data: Dict) -> None:
+        task_path = self.task_dir / name
+        if not task_path.is_dir():
+            raise FileNotFoundError("Task not found")
+
+        (task_path / "url_list.txt").write_text(url_list.strip(), encoding="utf-8")
+        (task_path / "interval.txt").write_text(str(interval), encoding="utf-8")
+
+        command = self._build_command(name, task_path, form_data)
+        (task_path / "command.txt").write_text(command, encoding="utf-8")
+
+    def _build_command(self, name: str, task_path: Path, form_data: Dict) -> str:
+        input_mode = form_data.get("input_mode", "i")
+        flags = []
+        for cli_flag, field in BOOLEAN_FLAGS.items():
+            if form_data.get(field):
+                flags.append(cli_flag)
+
+        for cli_flag, field in TEXT_FLAGS.items():
+            value = form_data.get(field)
+            if value:
+                flags.append(cli_flag)
+                flags.append(str(value))
+
+        if form_data.get("use_cookies"):
+            flags.append("-C")
+            flags.append("cookies.txt")
+
+        if form_data.get("use_download_archive"):
+            flags.append("--download-archive")
+            flags.append(f"{name}.sqlite")
+
+        input_part = f"-{input_mode} url_list.txt"
+        base_command = (
+            "gallery-dl -f /O -d /downloads --config /config/config.json --no-input "
+            "--verbose --write-log log.txt --no-part"
+        )
+        return " ".join([base_command, input_part, " ".join(flags)]).strip()
+
+    def delete_task(self, name: str) -> None:
+        path = self.task_dir / name
+        if not path.is_dir():
+            raise FileNotFoundError("Task not found")
+        shutil.rmtree(path)
+
+    def delete_archive(self, name: str) -> bool:
+        archive = self.task_dir / name / f"{name}.sqlite"
+        if archive.exists():
+            archive.unlink()
+            return True
+        return False
+
+    def toggle_pause(self, name: str) -> bool:
+        pause_file = self.task_dir / name / "paused.txt"
+        if pause_file.exists():
+            pause_file.unlink()
+            return False
+        pause_file.write_text("paused", encoding="utf-8")
+        return True
+
+    def run_task(self, name: str) -> subprocess.Popen:
+        task_path = self.task_dir / name
+        if not task_path.is_dir():
+            raise FileNotFoundError("Task not found")
+        return subprocess.Popen([self.python_bin, str(self.runner_task), str(task_path)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def run_single(self, url: str) -> subprocess.CompletedProcess:
+        if not re.match(r"^https?://", url):
+            raise ValueError("Invalid URL format")
+        return subprocess.run([self.python_bin, str(self.runner_single), url], capture_output=True, text=True)
+
+    def read_log(self, name: str) -> str:
+        log_path = self.task_dir / name / "log.txt"
+        if log_path.exists():
+            return log_path.read_text(encoding="utf-8", errors="replace")
+        return "Log not found."
+
+    def _read(self, path: Path) -> Optional[str]:
+        try:
+            return path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return None
+
+    def get_recent_images(self, cache_file: Path, cache_ttl: int = 120, limit: int = 200) -> List[str]:
+        cache_mtime = cache_file.stat().st_mtime if cache_file.exists() else 0
+        downloads_mtime = self.download_dir.stat().st_mtime if self.download_dir.exists() else 0
+
+        if cache_file.exists() and cache_mtime >= downloads_mtime and (datetime.now().timestamp() - cache_mtime) < cache_ttl:
+            try:
+                cached = json.loads(cache_file.read_text())
+                if isinstance(cached, dict):
+                    return cached.get("images", [])[:limit]
+                if isinstance(cached, list):
+                    return cached[:limit]
+            except Exception:
+                pass
+
+        files = [f for f in self.download_dir.glob("*") if f.is_file() and f.suffix.lower() in IMAGE_EXTENSIONS]
+        files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+        images = [f.name for f in files[:limit]]
+
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"time": datetime.now().timestamp(), "dir_mtime": downloads_mtime, "images": images}
+        cache_file.write_text(json.dumps(payload), encoding="utf-8")
+        return images

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title or 'Artillery' }}</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono&display=swap">
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            background-color: #181818;
+            color: #e0e0e0;
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            margin: 0;
+            padding: 0;
+            line-height: 1.5;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        a { color: #00b7c3; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        header.banner {
+            background-color: #252525;
+            padding: 1rem 1.5rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 1px solid #333;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+        .title { font-size: 1.75rem; color: #00b7c3; font-weight: 600; }
+        nav.nav { display: flex; gap: 1.25rem; }
+        nav.nav a { font-weight: 500; color: #00b7c3; }
+        main.content { flex: 1; width: 100%; max-width: 1200px; margin: 2rem auto; padding: 2rem; background: #252525; border-radius: 8px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3); }
+        footer.footer-banner { background: #252525; border-top: 1px solid #333; padding: 1rem 1.5rem; position: sticky; bottom: 0; }
+        .flash { padding: 0.75rem 1rem; border-radius: 6px; margin-bottom: 1rem; font-weight: 500; }
+        .flash.success { background: rgba(0, 183, 195, 0.15); color: #00c7d3; border: 1px solid #00b7c3; }
+        .flash.error { background: rgba(244, 67, 54, 0.15); color: #ff6b6b; border: 1px solid #e74c3c; }
+        .flash.info { background: rgba(255,255,255,0.08); color: #e0e0e0; border: 1px solid #444; }
+        button, .btn {
+            background: linear-gradient(135deg, #00b7c3, #008c95);
+            color: #fff;
+            border: none;
+            padding: 0.65rem 1.25rem;
+            border-radius: 6px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, background 0.2s ease;
+        }
+        button:hover, .btn:hover { background: linear-gradient(135deg, #00c7d3, #009ca5); transform: scale(1.02); }
+        .btn.secondary { background: linear-gradient(135deg, #546e7a, #455a64); }
+        .btn.secondary:hover { background: linear-gradient(135deg, #607d8b, #546e7a); }
+        .btn.danger { background: linear-gradient(135deg, #e74c3c, #c0392b); }
+        .btn.danger:hover { background: linear-gradient(135deg, #ff6b6b, #e74c3c); }
+        label { font-weight: 600; display: block; margin-top: 1rem; }
+        input[type="text"], input[type="number"], textarea {
+            width: 100%; padding: 0.75rem; background: #2e2e2e; color: #e0e0e0; border: 1px solid #444; border-radius: 6px; margin-top: 0.35rem; font-family: 'Inter', system-ui; }
+        input:focus, textarea:focus { border-color: #00b7c3; outline: none; box-shadow: 0 0 0 2px rgba(0,183,195,0.3); }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 0.75rem; text-align: left; border-bottom: 1px solid #333; }
+        th { color: #a0a0a0; font-weight: 600; text-transform: uppercase; font-size: 0.85rem; }
+        .status-badge { padding: 0.35rem 0.75rem; border-radius: 12px; font-weight: 700; font-size: 0.85rem; display: inline-block; }
+        .status-Running { background: rgba(0, 183, 195, 0.15); color: #00c7d3; border: 1px solid #00b7c3; }
+        .status-Idle { background: rgba(255,255,255,0.08); color: #e0e0e0; border: 1px solid #444; }
+        .status-Paused { background: rgba(255,193,7,0.18); color: #f0c674; border: 1px solid #d39e00; }
+    </style>
+</head>
+<body>
+<header class="banner">
+    <div class="title">ARTILLERY</div>
+    <nav class="nav">
+        <a href="{{ url_for('artillery.home') }}">Home</a>
+        <a href="{{ url_for('artillery.new_task') }}">New Task</a>
+        <a href="{{ url_for('artillery.list_tasks') }}">View Tasks</a>
+        <a href="{{ url_for('artillery.config_editor') }}">Config</a>
+    </nav>
+</header>
+<main class="content">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="flash {{ category }}">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</main>
+<footer class="footer-banner">
+    <div style="display:flex; align-items:center; justify-content: space-between;">
+        <div id="current-time"></div>
+        <a href="https://ko-fi.com/P5P61JA9LQ" target="_blank">Buy me a coffee</a>
+    </div>
+</footer>
+<script>
+    function updateCurrentTime() {
+        const now = new Date();
+        const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+        const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        const dayName = days[now.getDay()];
+        const day = String(now.getDate()).padStart(2, '0');
+        const month = months[now.getMonth()];
+        const year = now.getFullYear();
+        const hours = String(now.getHours()).padStart(2, '0');
+        const minutes = String(now.getMinutes()).padStart(2, '0');
+        const seconds = String(now.getSeconds()).padStart(2, '0');
+        const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        document.getElementById('current-time').textContent = `${dayName}, ${day} ${month} ${year} ${hours}:${minutes}:${seconds} ${timeZone}`;
+    }
+    updateCurrentTime();
+    setInterval(updateCurrentTime, 1000);
+</script>
+</body>
+</html>

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Config</h1>
+<p>Edit <code>/config/config.json</code>. A backup is written beside the file before saving.</p>
+<form method="post">
+    <label for="config_content">Config JSON</label>
+    <textarea id="config_content" name="config_content" rows="20" spellcheck="false">{{ content }}</textarea>
+    <div style="margin-top:1rem; display:flex; gap:0.75rem;">
+        <button type="submit">Save</button>
+        <a class="btn secondary" href="{{ url_for('artillery.home') }}">Cancel</a>
+    </div>
+</form>
+{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>One-off Download</h1>
+<p>Paste a gallery URL to trigger a single gallery-dl run. Recent images are shown below.</p>
+<form method="post" style="margin-bottom:1.5rem;">
+    <label for="gallery_url">Gallery URL</label>
+    <input type="text" id="gallery_url" name="gallery_url" placeholder="https://..." required>
+    <div style="margin-top:0.75rem; display:flex; gap:0.75rem; flex-wrap:wrap; align-items:center;">
+        <button type="submit">Start Download</button>
+    </div>
+</form>
+{% if output %}
+    <h2>Command Output</h2>
+    <pre style="background:#0f0f0f; color:#e0e0e0; padding:1rem; border-radius:8px; overflow:auto; max-height:320px;">{{ output }}</pre>
+{% endif %}
+
+<h2>Recent Images</h2>
+<div style="display:grid; grid-template-columns: repeat(auto-fill, minmax(160px,1fr)); gap:0.75rem;">
+    {% for img in images %}
+        <div style="background:#202020; padding:0.5rem; border-radius:6px; text-align:center;">
+            <img src="{{ url_for('artillery.downloads', filename=img) }}" alt="recent image" style="max-width:100%; border-radius:4px;">
+            <div style="font-size:0.8rem; color:#a0a0a0; margin-top:0.35rem;">{{ img }}</div>
+        </div>
+    {% else %}
+        <p>No images found in /downloads yet.</p>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/app/templates/log_view.html
+++ b/app/templates/log_view.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Log: {{ task_name }}</h1>
+<pre style="background:#0f0f0f; color:#e0e0e0; padding:1rem; border-radius:8px; white-space:pre-wrap;">{{ log_contents }}</pre>
+<div style="margin-top:1rem;">
+    <a class="btn" href="{{ url_for('artillery.list_tasks') }}">Back to tasks</a>
+</div>
+{% endblock %}

--- a/app/templates/task_form.html
+++ b/app/templates/task_form.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit Task' if mode == 'edit' else 'Create Task' }}</h1>
+<form method="post">
+    <label for="task_name">Task Name</label>
+    <input type="text" id="task_name" name="task_name" value="{{ task_name or '' }}" {% if mode == 'edit' %}readonly{% endif %} required>
+
+    <label for="url_list">URL List (one per line)</label>
+    <textarea id="url_list" name="url_list" rows="6" required>{{ task.url_list if task else '' }}</textarea>
+
+    <label for="interval">Interval (minutes)</label>
+    <input type="number" id="interval" name="interval" min="1" value="{{ task.interval if task else 60 }}" required>
+
+    <label>Input Mode</label>
+    <div style="display:flex; gap:1rem;">
+        <label><input type="radio" name="input_mode" value="i" {% if not task or task.input_mode == 'i' %}checked{% endif %}> -i (read list file)</label>
+        <label><input type="radio" name="input_mode" value="I" {% if task and task.input_mode == 'I' %}checked{% endif %}> -I (treat list as JSON)</label>
+    </div>
+
+    <h3>Flags</h3>
+    <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap:0.5rem;">
+        {% set flags = task.flags if task else {} %}
+        <label><input type="checkbox" name="write_unsupported" {% if flags.get('write_unsupported') %}checked{% endif %}> --write-unsupported</label>
+        <label><input type="checkbox" name="no_skip" {% if flags.get('no_skip') %}checked{% endif %}> --no-skip</label>
+        <label><input type="checkbox" name="write_metadata" {% if flags.get('write_metadata') %}checked{% endif %}> --write-metadata</label>
+        <label><input type="checkbox" name="write_info_json" {% if flags.get('write_info_json') %}checked{% endif %}> --write-info-json</label>
+        <label><input type="checkbox" name="write_tags" {% if flags.get('write_tags') %}checked{% endif %}> --write-tags</label>
+        <label><input type="checkbox" name="use_cookies" {% if task and task.use_cookies %}checked{% endif %}> -C cookies.txt</label>
+        <label><input type="checkbox" name="use_download_archive" {% if task and task.use_download_archive %}checked{% endif %}> --download-archive</label>
+    </div>
+
+    {% set values = task.values if task else {} %}
+    <h3>Flag values</h3>
+    <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap:0.75rem;">
+        <div><label>--retries<input type="text" name="retries" value="{{ values.get('retries','') }}"></label></div>
+        <div><label>--limit-rate<input type="text" name="limit_rate" value="{{ values.get('limit_rate','') }}"></label></div>
+        <div><label>--sleep<input type="text" name="sleep" value="{{ values.get('sleep','') }}"></label></div>
+        <div><label>--sleep-request<input type="text" name="sleep_request" value="{{ values.get('sleep_request','') }}"></label></div>
+        <div><label>--sleep-429<input type="text" name="sleep_429" value="{{ values.get('sleep_429','') }}"></label></div>
+        <div><label>--sleep-extractor<input type="text" name="sleep_extractor" value="{{ values.get('sleep_extractor','') }}"></label></div>
+        <div><label>--rename<input type="text" name="rename" value="{{ values.get('rename','') }}"></label></div>
+        <div><label>--rename-to<input type="text" name="rename_to" value="{{ values.get('rename_to','') }}"></label></div>
+    </div>
+
+    <div style="margin-top:1.5rem; display:flex; gap:0.75rem;">
+        <button type="submit">{{ 'Save Changes' if mode == 'edit' else 'Create Task' }}</button>
+        <a class="btn secondary" href="{{ url_for('artillery.list_tasks') }}">Cancel</a>
+    </div>
+</form>
+{% endblock %}

--- a/app/templates/tasks.html
+++ b/app/templates/tasks.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Tasks</h1>
+<p>Manage gallery-dl jobs. Launch, pause, edit, or delete tasks.</p>
+<div style="overflow-x:auto;">
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Interval (min)</th>
+            <th>Last Run</th>
+            <th>Next Run</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for task in tasks %}
+        <tr>
+            <td style="font-weight:700;">{{ task.display_name }}</td>
+            <td><span class="status-badge status-{{ task.status }}">{{ task.status }}</span></td>
+            <td>{{ task.interval }}</td>
+            <td>{{ task.last_run }}</td>
+            <td>{{ task.next_run }}</td>
+            <td style="display:flex; gap:0.35rem; flex-wrap:wrap;">
+                <form method="post" action="{{ url_for('artillery.run_task', task_name=task.name) }}">
+                    <button type="submit">Run</button>
+                </form>
+                <form method="post" action="{{ url_for('artillery.pause_task', task_name=task.name) }}">
+                    <button type="submit" class="btn secondary">{{ 'Resume' if task.status == 'Paused' else 'Pause' }}</button>
+                </form>
+                <a class="btn" href="{{ url_for('artillery.view_log', task_name=task.name) }}">Log</a>
+                <a class="btn" href="{{ url_for('artillery.edit_task', task_name=task.name) }}">Edit</a>
+                <form method="post" action="{{ url_for('artillery.delete_archive', task_name=task.name) }}">
+                    <button type="submit" class="btn secondary">Delete Archive</button>
+                </form>
+                <form method="post" action="{{ url_for('artillery.delete_task', task_name=task.name) }}" onsubmit="return confirm('Delete task {{ task.display_name }}?');">
+                    <button type="submit" class="btn danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6">No tasks have been created yet.</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+<div style="margin-top:1.5rem;">
+    <a class="btn" href="{{ url_for('artillery.new_task') }}">Create Task</a>
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+Flask
 croniter
-
-
-
+gallery-dl
+gunicorn

--- a/runner-scheduled.py
+++ b/runner-scheduled.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from croniter import croniter
 
 TASKS_DIR = "/tasks"
-RUNNER_SCRIPT = "/var/www/html/runner-task.py"
-PYTHON_BIN = "/opt/venv/bin/python3"
+RUNNER_SCRIPT = "/app/runner_task.py"
+PYTHON_BIN = "/usr/local/bin/python3"
 
 def log(msg):
     print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {msg}")

--- a/runner-single.py
+++ b/runner-single.py
@@ -1,35 +1,31 @@
 #!/usr/bin/env python3
-import sys
-import subprocess
-import os
 import re
-from datetime import datetime
+import subprocess
+import sys
+from pathlib import Path
 
-def main():
-    # Log environment info
-    print(f"Python executable: {sys.executable}")
-    print(f"Working directory: {os.getcwd()}")
 
-    # Ensure URL is passed
+def main() -> None:
     if len(sys.argv) < 2:
         print("Error: No URL provided", file=sys.stderr)
         sys.exit(1)
 
     url = sys.argv[1]
 
-    if not re.match(r'^https?://', url):
+    if not re.match(r"^https?://", url):
         print("Error: Invalid URL format", file=sys.stderr)
         sys.exit(1)
 
-    download_dir = "/downloads"
-    os.makedirs(download_dir, exist_ok=True)
+    download_dir = Path("/downloads")
+    download_dir.mkdir(parents=True, exist_ok=True)
 
     cmd = [
         "gallery-dl",
-        "--dest", download_dir,
+        "--dest",
+        str(download_dir),
         "--verbose",
         "--no-part",
-        url
+        url,
     ]
 
     print(f"Running: {' '.join(cmd)}")
@@ -45,6 +41,7 @@ def main():
     except FileNotFoundError:
         print("Error: gallery-dl not found. Ensure it's installed and in PATH.", file=sys.stderr)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,25 +4,18 @@ set -euo pipefail
 CONFIG_DIR="/config"
 LOGS_DIR="/logs"
 DOWNLOADS_DIR="/downloads"
-DIRECTORIES=($CONFIG_DIR $LOGS_DIR $DOWNLOADS_DIR)
+TASKS_DIR="/tasks"
+DIRECTORIES=($CONFIG_DIR $LOGS_DIR $DOWNLOADS_DIR $TASKS_DIR)
 
 for dir in "${DIRECTORIES[@]}"; do
-    if [ ! -d "$dir" ]; then
-        mkdir -p "$dir"
-    fi
-
-    # Attempt to ensure www-data owns the directory for PHP-FPM access
-    if id -u www-data >/dev/null 2>&1; then
-        chown -R www-data:www-data "$dir" 2>/dev/null || true
-    fi
-
+    mkdir -p "$dir"
     chmod 0777 "$dir" || true
-
 done
 
-if [ -x /opt/venv/bin/pip ]; then
+# Keep gallery-dl current if available in the image
+if command -v pip >/dev/null 2>&1; then
     echo "Updating gallery-dl to the latest version..."
-    if ! /opt/venv/bin/pip install --no-cache-dir --upgrade gallery-dl; then
+    if ! pip install --no-cache-dir --upgrade gallery-dl; then
         echo "Warning: Failed to update gallery-dl; continuing with existing version." >&2
     fi
 fi

--- a/scripts/update_recent_images.py
+++ b/scripts/update_recent_images.py
@@ -13,10 +13,8 @@ import os
 from pathlib import Path
 from typing import List
 
-# Repository paths
-REPO_ROOT = Path(__file__).resolve().parents[1]
-DOWNLOAD_DIR = REPO_ROOT / "downloads"
-LOG_DIR = REPO_ROOT / "logs"
+DOWNLOAD_DIR = Path(os.environ.get("DOWNLOAD_DIR", "/downloads"))
+LOG_DIR = Path(os.environ.get("LOG_DIR", "/logs"))
 CACHE_FILE = LOG_DIR / "image_cache.json"
 
 # Extensions considered as images

--- a/scripts/update_recent_images_service.py
+++ b/scripts/update_recent_images_service.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Background service to update recent images cache periodically."""
 
+import os
 import subprocess
 import sys
 import time
@@ -8,8 +9,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "update_recent_images.py"
-CACHE_FILE = REPO_ROOT / "logs" / "image_cache.json"
-INTERVAL = 3600  # seconds
+CACHE_FILE = Path(os.environ.get("LOG_DIR", "/logs")) / "image_cache.json"
+INTERVAL = int(os.environ.get("RECENT_IMAGES_INTERVAL", "3600"))
 
 
 def run_update() -> None:

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,27 +1,30 @@
 [supervisord]
 nodaemon=true
 
-[program:php-fpm]
-command=/usr/local/sbin/php-fpm -F
-
-[program:nginx]
-command=/usr/sbin/nginx -g "daemon off;"
-
-
-[program:watcher]
-command=/opt/venv/bin/python3 /var/www/html/watcher.py
+[program:gunicorn]
+command=/usr/local/bin/gunicorn -w 3 -b 0.0.0.0:8000 "app:create_app()"
+directory=/app
 autostart=true
 autorestart=true
-stderr_logfile=/logs/watcher-error.log
+stdout_logfile=/logs/gunicorn.log
+stderr_logfile=/logs/gunicorn-error.log
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+
+[program:watcher]
+command=/usr/local/bin/python /app/watcher.py
+autostart=true
+autorestart=true
 stdout_logfile=/logs/watcher.log
+stderr_logfile=/logs/watcher-error.log
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 
 [program:update_recent_images_service]
-command=/opt/venv/bin/python3 /var/www/html/scripts/update_recent_images_service.py
+command=/usr/local/bin/python /app/scripts/update_recent_images_service.py
 autostart=true
 autorestart=true
-stderr_logfile=/logs/update_recent_images_service-error.log
 stdout_logfile=/logs/update_recent_images_service.log
+stderr_logfile=/logs/update_recent_images_service-error.log
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0

--- a/watcher.py
+++ b/watcher.py
@@ -1,26 +1,28 @@
 import os
-import time
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 
-TASKS_DIR = Path("/tasks")
-RUNNER_SCRIPT = Path("/var/www/html/runner-scheduled.py")
-CHECK_INTERVAL = 60  # seconds
-LOG_PATH = Path("/logs/watcher.log")
+CHECK_INTERVAL = int(os.environ.get("WATCH_INTERVAL", "60"))
+TASKS_DIR = Path(os.environ.get("TASK_DIR", "/tasks"))
+RUNNER_SCRIPT = Path(os.environ.get("RUNNER_TASK", "/app/runner_task.py"))
+PYTHON_BIN = os.environ.get("PYTHON_BIN", sys.executable)
+LOG_PATH = Path(os.environ.get("LOG_DIR", "/logs")) / "watcher.log"
 
-# Ensure /logs directory exists
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
-def log(msg):
-    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+def log(msg: str) -> None:
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     message = f"[Watcher] {msg}"
     print(message)
     with open(LOG_PATH, "a", encoding="utf-8") as log_file:
-        log_file.write(f"{message}\n")
+        log_file.write(f"{timestamp} {message}\n")
 
-def clear_stale_lockfiles():
+
+def clear_stale_lockfiles() -> None:
     log("Clearing stale lockfiles...")
     removed = 0
     for task_dir in TASKS_DIR.iterdir():
@@ -30,31 +32,33 @@ def clear_stale_lockfiles():
                 try:
                     lockfile.unlink()
                     removed += 1
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     log(f"  - Failed to remove lockfile in '{task_dir.name}': {e}")
     log(f"Cleared {removed} stale lockfile(s).\n")
 
-def read_file(path):
+
+def read_file(path: Path) -> str | None:
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            return f.read().strip()
-    except Exception as e:
+        return path.read_text(encoding="utf-8").strip()
+    except Exception as e:  # noqa: BLE001
         log(f"  - Error reading {path.name}: {e}")
         return None
 
-def parse_last_run(path):
+
+def parse_last_run(path: Path):
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            return datetime.strptime(f.read().strip(), "%Y-%m-%d %H:%M:%S")
-    except:
+        return datetime.strptime(path.read_text(encoding="utf-8").strip(), "%Y-%m-%d %H:%M:%S")
+    except Exception:
         return None
 
-def should_run(interval_minutes, last_run, now):
+
+def should_run(interval_minutes: int, last_run, now: datetime) -> bool:
     if last_run is None:
         return True
     return now >= last_run + timedelta(minutes=interval_minutes)
 
-def main():
+
+def main() -> None:
     log("Starting up watcher...")
     clear_stale_lockfiles()
 
@@ -99,10 +103,9 @@ def main():
             if should_run(interval, last_run, now):
                 log("   ✓ Task is scheduled to run - passing to runner")
                 try:
-                    log(f"    > Executing: /opt/venv/bin/python3 /var/www/html/runner-task.py {task_dir}")
-
-                    subprocess.Popen(["/opt/venv/bin/python3", "/var/www/html/runner-task.py", str(task_dir)])
-                except Exception as e:
+                    log(f"    > Executing: {PYTHON_BIN} {RUNNER_SCRIPT} {task_dir}")
+                    subprocess.Popen([PYTHON_BIN, str(RUNNER_SCRIPT), str(task_dir)])
+                except Exception as e:  # noqa: BLE001
                     log(f"   - Error launching task: {e}")
             else:
                 log("   ✗ Task not scheduled to run now")
@@ -113,6 +116,7 @@ def main():
         next_scan = now + timedelta(seconds=CHECK_INTERVAL)
         log(f"Scan complete. Next scan at {next_scan.strftime('%Y-%m-%d %H:%M:%S')}.\n")
         time.sleep(CHECK_INTERVAL)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the PHP pages with a Flask UI, covering the home page, task management, logs, and config editing
- refresh the task runners, watcher, and image cache helpers to use the new Python paths and shared directories
- rebuild the container on Python 3.11 with gunicorn + supervisor handling the web app and background services

## Testing
- python -m compileall app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399467e7cc8320bc9326811dbecd6d)